### PR TITLE
Fix some regolith bugs

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -100,7 +100,7 @@ func applyTransaction(config *chain.Config, engine consensus.EngineReader, gp *G
 
 		// if the transaction created a contract, store the creation address in the receipt.
 		if msg.To() == nil {
-			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext().Origin, tx.GetNonce())
+			receipt.ContractAddress = crypto.CreateAddress(evm.TxContext().Origin, nonce)
 		}
 		// Set the receipt logs and create a bloom for filtering
 		receipt.Logs = ibs.GetLogs(tx.Hash())

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -466,7 +466,7 @@ func (tx AccessListTx) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (Mess
 		data:          tx.Data,
 		accessList:    tx.AccessList,
 		checkNonce:    true,
-		rollupDataGas: RollupDataGas(tx),
+		rollupDataGas: RollupDataGas(tx, rules),
 	}
 
 	if !rules.IsBerlin {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -206,7 +206,7 @@ func (tx *DepositTransaction) DecodeRLP(s *rlp.Stream) error {
 }
 
 // AsMessage returns the transaction as a core.Message.
-func (tx DepositTransaction) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (Message, error) {
+func (tx DepositTransaction) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (Message, error) {
 	msg := Message{
 		txType:        DepositTxType,
 		sourceHash:    tx.SourceHash,
@@ -219,7 +219,7 @@ func (tx DepositTransaction) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (Me
 		data:          tx.Data,
 		accessList:    nil,
 		checkNonce:    true,
-		rollupDataGas: RollupDataGas(tx),
+		rollupDataGas: RollupDataGas(tx, rules),
 	}
 	return msg, nil
 }

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -393,7 +393,7 @@ func (tx DynamicFeeTransaction) AsMessage(s Signer, baseFee *big.Int, rules *cha
 		data:          tx.Data,
 		accessList:    tx.AccessList,
 		checkNonce:    true,
-		rollupDataGas: RollupDataGas(tx),
+		rollupDataGas: RollupDataGas(tx, rules),
 	}
 	if !rules.IsLondon {
 		return msg, errors.New("eip-1559 transactions require London")

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -367,7 +367,7 @@ func (tx *LegacyTx) DecodeRLP(s *rlp.Stream, encodingSize uint64) error {
 }
 
 // AsMessage returns the transaction as a core.Message.
-func (tx LegacyTx) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (Message, error) {
+func (tx LegacyTx) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (Message, error) {
 	msg := Message{
 		nonce:         tx.Nonce,
 		gasLimit:      tx.Gas,
@@ -379,7 +379,7 @@ func (tx LegacyTx) AsMessage(s Signer, _ *big.Int, _ *chain.Rules) (Message, err
 		data:          tx.Data,
 		accessList:    nil,
 		checkNonce:    true,
-		rollupDataGas: RollupDataGas(tx),
+		rollupDataGas: RollupDataGas(tx, rules),
 	}
 
 	var err error

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -548,7 +548,8 @@ func (r Receipts) DeriveFields(config *chain.Config, hash libcommon.Hash, number
 			logIndex++
 		}
 	}
-	if config.IsOptimismBedrock(number) && len(txs) >= 2 { // need at least an info tx and a non-info tx
+	rules := config.Rules(number, time)
+	if rules.IsBedrock && len(txs) >= 2 { // need at least an info tx and a non-info tx
 		if data := txs[0].GetData(); len(data) >= 4+32*8 { // function selector + 8 arguments to setL1BlockValues
 			l1Basefee := new(uint256.Int).SetBytes(data[4+32*2 : 4+32*3]) // arg index 2
 			overhead := new(uint256.Int).SetBytes(data[4+32*6 : 4+32*7])  // arg index 6
@@ -558,7 +559,7 @@ func (r Receipts) DeriveFields(config *chain.Config, hash libcommon.Hash, number
 			feeScalar := new(big.Float).Quo(fscalar, fdivisor)
 			for i := 0; i < len(r); i++ {
 				if !txs[i].IsDepositTx() {
-					rollupDataGas := RollupDataGas(txs[i]) // Only fake txs for RPC view-calls are 0.
+					rollupDataGas := RollupDataGas(txs[i], rules) // Only fake txs for RPC view-calls are 0.
 					r[i].L1GasPrice = l1Basefee.ToBig()
 					// GasUsed reported in receipt should include the overhead
 					r[i].L1GasUsed = new(big.Int).Add(new(big.Int).SetUint64(rollupDataGas), overhead.ToBig())

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -129,7 +129,7 @@ func (tm TransactionMisc) From() *atomic.Value {
 	return &tm.from
 }
 
-func RollupDataGas(tx binMarshalable) uint64 {
+func RollupDataGas(tx binMarshalable, rules *chain.Rules) uint64 {
 	var buf bytes.Buffer
 	if err := tx.MarshalBinary(&buf); err != nil {
 		// Silent error, invalid txs will not be marshalled/unmarshalled for batch submission anyway.
@@ -146,7 +146,12 @@ func RollupDataGas(tx binMarshalable) uint64 {
 		}
 	}
 	zeroesGas := zeroes * params.TxDataZeroGas
-	onesGas := (ones + 68) * params.TxDataNonZeroGasEIP2028
+	var onesGas uint64
+	if rules.IsOptimismRegolith {
+		onesGas = ones * params.TxDataNonZeroGasEIP2028
+	} else {
+		onesGas = (ones + 68) * params.TxDataNonZeroGasEIP2028
+	}
 	total := zeroesGas + onesGas
 	log.Info("MMDBG computing rollupDataGas", "total", total, "tx", tx)
 	return total

--- a/turbo/jsonrpc/eth_receipts_test.go
+++ b/turbo/jsonrpc/eth_receipts_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/holiman/uint256"
+	"github.com/ledgerwatch/erigon-lib/chain"
 	"github.com/ledgerwatch/erigon-lib/common"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon-lib/gointerfaces/txpool"
@@ -125,13 +126,13 @@ func TestGetReceipts(t *testing.T) {
 	require.Equal(t, 2, len(receipts))
 
 	require.Equal(t, new(uint256.Int).SetBytes(l1BaseFee[:]).ToBig(), receipts[0].L1GasPrice)
-	rollupDataGas1 := types.RollupDataGas(tx1)
+	rollupDataGas1 := types.RollupDataGas(tx1, &chain.Rules{IsBedrock: true})
 	require.Equal(t, new(big.Int).Add(new(big.Int).SetUint64(rollupDataGas1), new(uint256.Int).SetBytes(overhead[:]).ToBig()), receipts[0].L1GasUsed)
 	require.Equal(t, types.L1Cost(rollupDataGas1, new(uint256.Int).SetBytes(l1BaseFee[:]), new(uint256.Int).SetBytes(overhead[:]), new(uint256.Int).SetBytes(scalar[:])).ToBig(), receipts[0].L1Fee)
 	require.Equal(t, feeScalar, receipts[0].FeeScalar)
 
 	require.Equal(t, new(uint256.Int).SetBytes(l1BaseFee[:]).ToBig(), receipts[1].L1GasPrice)
-	rollupDataGas2 := types.RollupDataGas(tx2)
+	rollupDataGas2 := types.RollupDataGas(tx2, &chain.Rules{IsBedrock: true})
 	require.Equal(t, new(big.Int).Add(new(big.Int).SetUint64(rollupDataGas2), new(uint256.Int).SetBytes(overhead[:]).ToBig()), receipts[1].L1GasUsed)
 	require.Equal(t, types.L1Cost(rollupDataGas2, new(uint256.Int).SetBytes(l1BaseFee[:]), new(uint256.Int).SetBytes(overhead[:]), new(uint256.Int).SetBytes(scalar[:])).ToBig(), receipts[1].L1Fee)
 	require.Equal(t, feeScalar, receipts[1].FeeScalar)


### PR DESCRIPTION
This patch fixes three distinct issues (broken into three commits).

1. When a deposit transaction creates a new contract, the nonce was not being set correctly for the contract creation.
2. When a deposit transaction is processed under Regolith, the actual gas used should be reported for the transaction, not the gas limit as was done in Bedrock.
3. When transactions have their rollup data gas computed, the computation differs for Regolith and therefore requires a parameter indicating the network conditions.

With these three fixes in place, the previously failing op-e2e p2p sync test succeeds again, and all other passing tests still pass.