### PR TITLE
Test Erigon in Bedrock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+# this allows you to use CircleCI's dynamic configuration feature
+setup: true
+
+# the continuation orb is required in order to use dynamic configuration
+orbs:
+  continuation: circleci/continuation@0.1.2
+
+# our defined job, and its steps
+jobs:
+  setup:
+    executor: continuation/default
+    steps:
+      - checkout 
+      - run: 
+          name: Pull v3-anchorage
+          command: git clone https://github.com/bobanetwork/v3-anchorage
+      - continuation/continue:
+          configuration_path: v3-anchorage/.circleci/config.yml # use newly generated config to continue
+
+# our single workflow, that triggers the setup job defined above
+workflows:
+  setup:
+    jobs:
+      - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,13 @@ jobs:
       image: ubuntu-2204:2022.07.1
       resource_class: medium
     steps:
-      - run: git clone https://github.com/bobanetwork/v3-anchorage .
+      #- checkout modifying the checkout step so that we can clone into a directory
+      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" v3-erigon/
+      - run: git clone https://github.com/bobanetwork/v3-anchorage v3-anchorage/
       - persist_to_workspace:
           root: "."
           paths:
-            - "v3-anchorage"
+            - "."
 
   go-e2e-test:
     parameters:
@@ -27,24 +29,31 @@ jobs:
     steps:
       - attach_workspace: { at: "." }
       - run:
+          name: Print go version
+          command: go version
+      - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results
+          working_directory: ~/v3-anchorage
       - run:
           name: install geth
           command: ls -altr && make install-geth
+          working_directory: ~/v3-anchorage
       - run:
           name: git submodules
           command: git submodule update --init --recursive
+          working_directory: ~/v3-anchorage
       - run:
           name: print go's available MIPS targets
           command: go tool dist list | grep mips
+          working_directory: ~/v3-anchorage
       - run:
           name: run tests
           command:
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
             JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>>
-          working_directory: <<parameters.module>>
+          working_directory: ~/v3-anchorage/<<parameters.module>>
       - store_test_results:
           path: /tmp/test-results
 
@@ -53,18 +62,18 @@ workflows:
   main:
     jobs:
       - v3-achorage-checkout
-      - go-e2e-test:
-          name: op-e2e-WS-tests
-          module: op-e2e
-          target: test-ws
-          requires:
-            - v3-achorage-checkout
-      - go-e2e-test:
-          name: op-e2e-HTTP-tests
-          module: op-e2e
-          target: test-http
-          requires:
-            - v3-achorage-checkout             
+      # - go-e2e-test:
+      #     name: op-e2e-WS-tests
+      #     module: op-e2e
+      #     target: test-ws
+      #     requires:
+      #       - v3-achorage-checkout
+      # - go-e2e-test:
+      #     name: op-e2e-HTTP-tests
+      #     module: op-e2e
+      #     target: test-http
+      #     requires:
+      #       - v3-achorage-checkout             
       - go-e2e-test:
           name: op-e2e-ext-erigon-tests
           module: op-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,73 @@
 version: 2.1
 
-# this allows you to use CircleCI's dynamic configuration feature
-setup: true
-
-# the continuation orb is required in order to use dynamic configuration
-orbs:
-  continuation: circleci/continuation@0.1.2
-
 # our defined job, and its steps
 jobs:
-  setup:
-    executor: continuation/default
+  v3-achorage-checkout:
+    machine:
+      image: ubuntu-2204:2022.07.1
+      resource_class: medium
     steps:
-      - checkout 
-      - run: 
-          name: Pull v3-anchorage
-          command: git clone https://github.com/bobanetwork/v3-anchorage
-      - continuation/continue:
-          configuration_path: v3-anchorage/.circleci/config.yml # use newly generated config to continue
+      - run: git clone https://github.com/bobanetwork/v3-anchorage .
+      - persist_to_workspace:
+          root: "."
+          paths:
+            - "v3-anchorage"
+
+  go-e2e-test:
+    parameters:
+      module:
+        description: Go Module Name
+        type: string
+      target:
+        description: The make target to execute
+        type: string
+    docker:
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+    resource_class: xlarge
+    steps:
+      - attach_workspace: { at: "." }
+      - run:
+          name: prep results dir
+          command: mkdir -p /tmp/test-results
+      - run:
+          name: install geth
+          command: ls -altr && make install-geth
+      - run:
+          name: git submodules
+          command: git submodule update --init --recursive
+      - run:
+          name: print go's available MIPS targets
+          command: go tool dist list | grep mips
+      - run:
+          name: run tests
+          command:
+            # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
+            # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
+            JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>>
+          working_directory: <<parameters.module>>
+      - store_test_results:
+          path: /tmp/test-results
 
 # our single workflow, that triggers the setup job defined above
 workflows:
-  setup:
+  main:
     jobs:
-      - setup
+      - v3-achorage-checkout
+      - go-e2e-test:
+          name: op-e2e-WS-tests
+          module: op-e2e
+          target: test-ws
+          requires:
+            - v3-achorage-checkout
+      - go-e2e-test:
+          name: op-e2e-HTTP-tests
+          module: op-e2e
+          target: test-http
+          requires:
+            - v3-achorage-checkout             
+      - go-e2e-test:
+          name: op-e2e-ext-erigon-tests
+          module: op-e2e
+          target: test-external-erigon
+          requires:
+            - v3-achorage-checkout    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,14 @@ jobs:
       image: ubuntu-2204:2022.07.1
       resource_class: medium
     steps:
-      #- checkout modifying the checkout step so that we can clone into a directory
+      #modifying the usual checkout step so that we can clone two projects into a directory ~/project/<>
       - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" v3-erigon/
       - run: git clone https://github.com/bobanetwork/v3-anchorage v3-anchorage/
       - persist_to_workspace:
           root: "."
           paths:
-            - "."
+            - "v3-erigon/"
+            - "v3-anchorage/"
 
   go-e2e-test:
     parameters:
@@ -29,51 +30,42 @@ jobs:
     steps:
       - attach_workspace: { at: "." }
       - run:
-          name: Print go version
-          command: go version
+          name: Modify target Erigon
+          command: |
+            cp ~/project/v3-erigon/go.mod ~/project/v3-anchorage/op-erigon/go.mod
+            cd ~/project/v3-anchorage/op-erigon 
+            go mod edit -module="github.com/ethereum-optimism/optimism/op-erigon" && go mod edit -replace "github.com/ledgerwatch/erigon=github.com/bobanetwork/v3-erigon@$CIRCLE_SHA1" 
+            go mod tidy
       - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results
-          working_directory: ~/v3-anchorage
+          working_directory: ~/project/v3-anchorage
       - run:
           name: install geth
-          command: ls -altr && make install-geth
-          working_directory: ~/v3-anchorage
+          command: make install-geth
+          working_directory: ~/project/v3-anchorage
       - run:
           name: git submodules
           command: git submodule update --init --recursive
-          working_directory: ~/v3-anchorage
+          working_directory: ~/project/v3-anchorage
       - run:
           name: print go's available MIPS targets
           command: go tool dist list | grep mips
-          working_directory: ~/v3-anchorage
+          working_directory: ~/project/v3-anchorage
       - run:
           name: run tests
           command:
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
             JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>>
-          working_directory: ~/v3-anchorage/<<parameters.module>>
+          working_directory: ~/project/v3-anchorage/<<parameters.module>>
       - store_test_results:
           path: /tmp/test-results
 
-# our single workflow, that triggers the setup job defined above
 workflows:
   main:
     jobs:
-      - v3-achorage-checkout
-      # - go-e2e-test:
-      #     name: op-e2e-WS-tests
-      #     module: op-e2e
-      #     target: test-ws
-      #     requires:
-      #       - v3-achorage-checkout
-      # - go-e2e-test:
-      #     name: op-e2e-HTTP-tests
-      #     module: op-e2e
-      #     target: test-http
-      #     requires:
-      #       - v3-achorage-checkout             
+      - v3-achorage-checkout           
       - go-e2e-test:
           name: op-e2e-ext-erigon-tests
           module: op-e2e


### PR DESCRIPTION
This PR adds testing Erigon towards Bedrock suite of tests.
Steps are pretty self explanatory:
- git clone the current PR
- git clone v3-anchorage  default branch (which is develop)
- modify the target Erigon in op-erigon in v3-achorage
- execute Bedrock e2e tests
- prosper

Cirleci steps are more or less taken from v3-anchora cirleci, I also imported their env vars!