### PR TITLE
Remove EffectiveGasPrice in receipt

### DIFF
--- a/core/types/gen_genesis.go
+++ b/core/types/gen_genesis.go
@@ -27,16 +27,16 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 		Difficulty            *math.HexOrDecimal256                        `json:"difficulty" gencodec:"required"`
 		Mixhash               common.Hash                                  `json:"mixHash"`
 		Coinbase              common.Address                               `json:"coinbase"`
-		BaseFee               *math.HexOrDecimal256                        `json:"baseFeePerGas"`
-		BlobGasUsed           *math.HexOrDecimal64                         `json:"blobGasUsed"`
-		ExcessBlobGas         *math.HexOrDecimal64                         `json:"excessBlobGas"`
 		Alloc                 map[common0.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
 		AuRaStep              uint64                                       `json:"auRaStep"`
 		AuRaSeal              []byte                                       `json:"auRaSeal"`
-		ParentBeaconBlockRoot *common.Hash                                 `json:"parentBeaconBlockRoot"`
 		Number                math.HexOrDecimal64                          `json:"number"`
 		GasUsed               math.HexOrDecimal64                          `json:"gasUsed"`
 		ParentHash            common.Hash                                  `json:"parentHash"`
+		BaseFee               *math.HexOrDecimal256                        `json:"baseFeePerGas"`
+		BlobGasUsed           *math.HexOrDecimal64                         `json:"blobGasUsed"`
+		ExcessBlobGas         *math.HexOrDecimal64                         `json:"excessBlobGas"`
+		ParentBeaconBlockRoot *common.Hash                                 `json:"parentBeaconBlockRoot"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -47,9 +47,6 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.Difficulty = (*math.HexOrDecimal256)(g.Difficulty)
 	enc.Mixhash = g.Mixhash
 	enc.Coinbase = g.Coinbase
-	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
-	enc.BlobGasUsed = (*math.HexOrDecimal64)(g.BlobGasUsed)
-	enc.ExcessBlobGas = (*math.HexOrDecimal64)(g.ExcessBlobGas)
 	if g.Alloc != nil {
 		enc.Alloc = make(map[common0.UnprefixedAddress]GenesisAccount, len(g.Alloc))
 		for k, v := range g.Alloc {
@@ -58,10 +55,13 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	}
 	enc.AuRaStep = g.AuRaStep
 	enc.AuRaSeal = g.AuRaSeal
-	enc.ParentBeaconBlockRoot = g.ParentBeaconBlockRoot
 	enc.Number = math.HexOrDecimal64(g.Number)
 	enc.GasUsed = math.HexOrDecimal64(g.GasUsed)
 	enc.ParentHash = g.ParentHash
+	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
+	enc.BlobGasUsed = (*math.HexOrDecimal64)(g.BlobGasUsed)
+	enc.ExcessBlobGas = (*math.HexOrDecimal64)(g.ExcessBlobGas)
+	enc.ParentBeaconBlockRoot = g.ParentBeaconBlockRoot
 	return json.Marshal(&enc)
 }
 
@@ -76,16 +76,16 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		Difficulty            *math.HexOrDecimal256                        `json:"difficulty" gencodec:"required"`
 		Mixhash               *common.Hash                                 `json:"mixHash"`
 		Coinbase              *common.Address                              `json:"coinbase"`
-		BaseFee               *math.HexOrDecimal256                        `json:"baseFeePerGas"`
-		BlobGasUsed           *math.HexOrDecimal64                         `json:"blobGasUsed"`
-		ExcessBlobGas         *math.HexOrDecimal64                         `json:"excessBlobGas"`
 		Alloc                 map[common0.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
 		AuRaStep              *uint64                                      `json:"auRaStep"`
 		AuRaSeal              []byte                                       `json:"auRaSeal"`
-		ParentBeaconBlockRoot *common.Hash                                 `json:"parentBeaconBlockRoot"`
 		Number                *math.HexOrDecimal64                         `json:"number"`
 		GasUsed               *math.HexOrDecimal64                         `json:"gasUsed"`
 		ParentHash            *common.Hash                                 `json:"parentHash"`
+		BaseFee               *math.HexOrDecimal256                        `json:"baseFeePerGas"`
+		BlobGasUsed           *math.HexOrDecimal64                         `json:"blobGasUsed"`
+		ExcessBlobGas         *math.HexOrDecimal64                         `json:"excessBlobGas"`
+		ParentBeaconBlockRoot *common.Hash                                 `json:"parentBeaconBlockRoot"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -117,15 +117,6 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 	if dec.Coinbase != nil {
 		g.Coinbase = *dec.Coinbase
 	}
-	if dec.BaseFee != nil {
-		g.BaseFee = (*big.Int)(dec.BaseFee)
-	}
-	if dec.BlobGasUsed != nil {
-		g.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
-	}
-	if dec.ExcessBlobGas != nil {
-		g.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
-	}
 	if dec.Alloc == nil {
 		return errors.New("missing required field 'alloc' for Genesis")
 	}
@@ -139,9 +130,6 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 	if dec.AuRaSeal != nil {
 		g.AuRaSeal = dec.AuRaSeal
 	}
-	if dec.ParentBeaconBlockRoot != nil {
-		g.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
-	}
 	if dec.Number != nil {
 		g.Number = uint64(*dec.Number)
 	}
@@ -150,6 +138,18 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentHash != nil {
 		g.ParentHash = *dec.ParentHash
+	}
+	if dec.BaseFee != nil {
+		g.BaseFee = (*big.Int)(dec.BaseFee)
+	}
+	if dec.BlobGasUsed != nil {
+		g.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
+	}
+	if dec.ExcessBlobGas != nil {
+		g.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.ParentBeaconBlockRoot != nil {
+		g.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
 	}
 	return nil
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -26,7 +26,6 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		TxHash            common.Hash      `json:"transactionHash" gencodec:"required" codec:"-"`
 		ContractAddress   common.Address   `json:"contractAddress" codec:"-"`
 		GasUsed           hexutil.Uint64   `json:"gasUsed" gencodec:"required" codec:"-"`
-		EffectiveGasPrice *big.Int         `json:"effectiveGasPrice"`
 		DepositNonce      *uint64          `json:"depositNonce,omitempty"`
 		BlockHash         common.Hash      `json:"blockHash,omitempty" codec:"-"`
 		BlockNumber       *hexutil.Big     `json:"blockNumber,omitempty" codec:"-"`
@@ -46,7 +45,6 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.TxHash = r.TxHash
 	enc.ContractAddress = r.ContractAddress
 	enc.GasUsed = hexutil.Uint64(r.GasUsed)
-	enc.EffectiveGasPrice = r.EffectiveGasPrice
 	enc.DepositNonce = r.DepositNonce
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
@@ -70,7 +68,6 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		TxHash            *common.Hash      `json:"transactionHash" gencodec:"required" codec:"-"`
 		ContractAddress   *common.Address   `json:"contractAddress" codec:"-"`
 		GasUsed           *hexutil.Uint64   `json:"gasUsed" gencodec:"required" codec:"-"`
-		EffectiveGasPrice *big.Int          `json:"effectiveGasPrice"`
 		DepositNonce      *uint64           `json:"depositNonce,omitempty"`
 		BlockHash         *common.Hash      `json:"blockHash,omitempty" codec:"-"`
 		BlockNumber       *hexutil.Big      `json:"blockNumber,omitempty" codec:"-"`
@@ -116,9 +113,6 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'gasUsed' for Receipt")
 	}
 	r.GasUsed = uint64(*dec.GasUsed)
-	if dec.EffectiveGasPrice != nil {
-		r.EffectiveGasPrice = dec.EffectiveGasPrice
-	}
 	if dec.DepositNonce != nil {
 		r.DepositNonce = dec.DepositNonce
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -62,10 +62,9 @@ type Receipt struct {
 
 	// Implementation fields: These fields are added by geth when processing a transaction.
 	// They are stored in the chain database.
-	TxHash            libcommon.Hash    `json:"transactionHash" gencodec:"required" codec:"-"`
-	ContractAddress   libcommon.Address `json:"contractAddress" codec:"-"`
-	GasUsed           uint64            `json:"gasUsed" gencodec:"required" codec:"-"`
-	EffectiveGasPrice *big.Int          `json:"effectiveGasPrice"`
+	TxHash          libcommon.Hash    `json:"transactionHash" gencodec:"required" codec:"-"`
+	ContractAddress libcommon.Address `json:"contractAddress" codec:"-"`
+	GasUsed         uint64            `json:"gasUsed" gencodec:"required" codec:"-"`
 
 	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions
 	// The state transition process ensures this is only set for Regolith deposit transactions.

--- a/core/types/receipt_codecgen_gen.go
+++ b/core/types/receipt_codecgen_gen.go
@@ -64,13 +64,12 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 			yy2arr2 := z.EncBasicHandle().StructToArray
 			_ = yy2arr2
 			const yyr2 bool = false // struct tag has 'toArray'
-			var yyn7 bool = x.EffectiveGasPrice == nil
-			var yyn8 bool = x.DepositNonce == nil
-			var yyn9 bool = x.L1GasPrice == nil
-			var yyn10 bool = x.L1GasUsed == nil
-			var yyn11 bool = x.L1Fee == nil
-			var yyn12 bool = x.FeeScalar == nil
-			z.EncWriteArrayStart(10)
+			var yyn7 bool = x.DepositNonce == nil
+			var yyn8 bool = x.L1GasPrice == nil
+			var yyn9 bool = x.L1GasUsed == nil
+			var yyn10 bool = x.L1Fee == nil
+			var yyn11 bool = x.FeeScalar == nil
+			z.EncWriteArrayStart(9)
 			z.EncWriteArrayElem()
 			r.EncodeUint(uint64(x.Type))
 			z.EncWriteArrayElem()
@@ -88,21 +87,10 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 				r.EncodeNil()
 			} else {
 				z.EncWriteArrayElem()
-				if !z.EncBinary() && z.IsJSONHandle() {
-					z.EncJSONMarshal(x.EffectiveGasPrice)
-				} else {
-					z.EncFallback(x.EffectiveGasPrice)
-				}
+				yy16 := *x.DepositNonce
+				r.EncodeUint(uint64(yy16))
 			}
 			if yyn8 {
-				z.EncWriteArrayElem()
-				r.EncodeNil()
-			} else {
-				z.EncWriteArrayElem()
-				yy18 := *x.DepositNonce
-				r.EncodeUint(uint64(yy18))
-			}
-			if yyn9 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -113,7 +101,7 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(x.L1GasPrice)
 				}
 			}
-			if yyn10 {
+			if yyn9 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -124,7 +112,7 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(x.L1GasUsed)
 				}
 			}
-			if yyn11 {
+			if yyn10 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -135,7 +123,7 @@ func (x *Receipt) CodecEncodeSelf(e *codec1978.Encoder) {
 					z.EncFallback(x.L1Fee)
 				}
 			}
-			if yyn12 {
+			if yyn11 {
 				z.EncWriteArrayElem()
 				r.EncodeNil()
 			} else {
@@ -207,21 +195,6 @@ func (x *Receipt) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			x.Status = (uint64)(r.DecodeUint64())
 		case "3":
 			x.CumulativeGasUsed = (uint64)(r.DecodeUint64())
-		case "EffectiveGasPrice":
-			if r.TryNil() {
-				if x.EffectiveGasPrice != nil { // remove the if-true
-					x.EffectiveGasPrice = nil
-				}
-			} else {
-				if x.EffectiveGasPrice == nil {
-					x.EffectiveGasPrice = new(pkg2_big.Int)
-				}
-				if !z.DecBinary() && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(x.EffectiveGasPrice)
-				} else {
-					z.DecFallback(x.EffectiveGasPrice, false)
-				}
-			}
 		case "DepositNonce":
 			if r.TryNil() {
 				if x.DepositNonce != nil { // remove the if-true
@@ -303,89 +276,64 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer2
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj21 int
-	var yyb21 bool
-	var yyhl21 bool = l >= 0
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	var yyj19 int
+	var yyb19 bool
+	var yyhl19 bool = l >= 0
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.Type = (uint8)(z.C.UintV(r.DecodeUint64(), 8))
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.PostState = r.DecodeBytes(([]byte)(x.PostState), false)
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.Status = (uint64)(r.DecodeUint64())
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
 	z.DecReadArrayElem()
 	x.CumulativeGasUsed = (uint64)(r.DecodeUint64())
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
-		z.DecReadArrayEnd()
-		return
-	}
-	z.DecReadArrayElem()
-	if r.TryNil() {
-		if x.EffectiveGasPrice != nil { // remove the if-true
-			x.EffectiveGasPrice = nil
-		}
-	} else {
-		if x.EffectiveGasPrice == nil {
-			x.EffectiveGasPrice = new(pkg2_big.Int)
-		}
-		if !z.DecBinary() && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(x.EffectiveGasPrice)
-		} else {
-			z.DecFallback(x.EffectiveGasPrice, false)
-		}
-	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
-	} else {
-		yyb21 = z.DecCheckBreak()
-	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -400,13 +348,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		*x.DepositNonce = (uint64)(r.DecodeUint64())
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -425,13 +373,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1GasPrice, false)
 		}
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -450,13 +398,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1GasUsed, false)
 		}
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -475,13 +423,13 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 			z.DecFallback(x.L1Fee, false)
 		}
 	}
-	yyj21++
-	if yyhl21 {
-		yyb21 = yyj21 > l
+	yyj19++
+	if yyhl19 {
+		yyb19 = yyj19 > l
 	} else {
-		yyb21 = z.DecCheckBreak()
+		yyb19 = z.DecCheckBreak()
 	}
-	if yyb21 {
+	if yyb19 {
 		z.DecReadArrayEnd()
 		return
 	}
@@ -501,17 +449,17 @@ func (x *Receipt) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 	}
 	for {
-		yyj21++
-		if yyhl21 {
-			yyb21 = yyj21 > l
+		yyj19++
+		if yyhl19 {
+			yyb19 = yyj19 > l
 		} else {
-			yyb21 = z.DecCheckBreak()
+			yyb19 = z.DecCheckBreak()
 		}
-		if yyb21 {
+		if yyb19 {
 			break
 		}
 		z.DecReadArrayElem()
-		z.DecStructFieldNotFound(yyj21-1, "")
+		z.DecStructFieldNotFound(yyj19-1, "")
 	}
 }
 

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -770,7 +770,6 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         types.CreateBloom(types.Receipts{receipt}),
-		"effectiveGasPrice": (*hexutil.Big)(receipt.EffectiveGasPrice),
 	}
 	if chainConfig.Optimism != nil && !txn.IsDepositTx() {
 		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
@@ -781,7 +780,6 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 	if chainConfig.Optimism != nil && txn.IsDepositTx() && receipt.DepositNonce != nil {
 		fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
 	}
-
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(txn.GetPrice().Uint64())
 	} else {


### PR DESCRIPTION
It removes the unnecessary field in the receipt. The `effectiveGasPrice` field will be appended during the `marshalReceipt` in https://github.com/bobanetwork/v3-erigon/blob/boba-develop/turbo/jsonrpc/eth_receipts.go