### PR TITLE
Close seqRPCService and historicalRPCService in the end

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -1310,6 +1310,13 @@ func (s *Ethereum) Stop() error {
 		s.silkworm.Close()
 	}
 
+	if s.seqRPCService != nil {
+		s.seqRPCService.Close()
+	}
+	if s.historicalRPCService != nil {
+		s.historicalRPCService.Close()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This stops the seqRPCService and historicalRPCService when the node stops.