### PR TITLE
Write the genesis block as the first forkchoice

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -294,6 +294,13 @@ func write(tx kv.RwTx, g *types.Genesis, tmpDir string) (*types.Block, *state.In
 		return nil, nil, err
 	}
 
+	if g.Config.TerminalTotalDifficultyPassed {
+		// The genesis block is implicitly the first fork choice in PoS Networks
+		rawdb.WriteForkchoiceHead(tx, block.Hash())
+		rawdb.WriteForkchoiceFinalized(tx, block.Hash())
+		rawdb.WriteForkchoiceSafe(tx, block.Hash())
+	}
+
 	// We support ethash/merge for issuance (for now)
 	if g.Config.Consensus != chain.EtHashConsensus {
 		return block, statedb, nil


### PR DESCRIPTION
The assorted GetBlockByNumber calls for "finalized" and "safe" fail when no new blocks have been added because they are not yet encoded in the DB.  This simply adds them to the db at genesis time.