### PR TITLE
Align with op-erigon

### DIFF
--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -78,12 +78,14 @@ type HttpCfg struct {
 	ReturnDataLimit             int  // Maximum number of bytes returned from calls (like eth_call)
 	AllowUnprotectedTxs         bool // Whether to allow non EIP-155 protected transactions  txs over RPC
 	MaxGetProofRewindBlockCount int  //Max GetProof rewind block count
+
+	// Optimism
+	RollupSequencerHTTP        string
+	RollupHistoricalRPC        string
+	RollupHistoricalRPCTimeout time.Duration
+
 	// Ots API
 	OtsMaxPageSize uint64
 
 	RPCSlowLogThreshold time.Duration
-
-	RollupSequencerHTTP        string
-	RollupHistoricalRPC        string
-	RollupHistoricalRPCTimeout time.Duration
 }

--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -56,6 +56,7 @@ var (
 	priceBump     uint64
 	blobPriceBump uint64
 
+	optimism   bool
 	noTxGossip bool
 
 	commitEvery time.Duration
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint64Var(&priceBump, "txpool.pricebump", txpoolcfg.DefaultConfig.PriceBump, "Price bump percentage to replace an already existing transaction")
 	rootCmd.PersistentFlags().Uint64Var(&blobPriceBump, "txpool.blobpricebump", txpoolcfg.DefaultConfig.BlobPriceBump, "Price bump percentage to replace an existing blob (type-3) transaction")
 	rootCmd.PersistentFlags().DurationVar(&commitEvery, utils.TxPoolCommitEveryFlag.Name, utils.TxPoolCommitEveryFlag.Value, utils.TxPoolCommitEveryFlag.Usage)
+	rootCmd.PersistentFlags().BoolVar(&optimism, "txpool.optimism", txpoolcfg.DefaultConfig.Optimism, "Enable Optimism Bedrock to make txpool account for L1 cost of transactions")
 	rootCmd.PersistentFlags().BoolVar(&noTxGossip, utils.TxPoolGossipDisableFlag.Name, utils.TxPoolGossipDisableFlag.Value, utils.TxPoolGossipDisableFlag.Usage)
 	rootCmd.Flags().StringSliceVar(&traceSenders, utils.TxPoolTraceSendersFlag.Name, []string{}, utils.TxPoolTraceSendersFlag.Usage)
 }
@@ -151,6 +153,8 @@ func doTxpool(ctx context.Context, logger log.Logger) error {
 	cfg.PriceBump = priceBump
 	cfg.BlobPriceBump = blobPriceBump
 	cfg.NoGossip = noTxGossip
+
+	cfg.Optimism = optimism
 
 	cacheConfig := kvcache.DefaultCoherentConfig
 	cacheConfig.MetricsLabel = "txpool"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -108,9 +108,17 @@ var (
 		Name:  "whitelist",
 		Usage: "Comma separated block number-to-hash mappings to enforce (<number>=<hash>)",
 	}
+	OverrideShanghaiTime = flags.BigFlag{
+		Name:  "override.shanghai",
+		Usage: "Manually specify the Shanghai fork time, overriding the bundled setting",
+	}
 	OverrideCancunFlag = flags.BigFlag{
 		Name:  "override.cancun",
 		Usage: "Manually specify the Cancun fork time, overriding the bundled setting",
+	}
+	TrustedSetupFile = cli.StringFlag{
+		Name:  "trusted-setup-file",
+		Usage: "Absolute path to trusted_setup.json file",
 	}
 	OverrideOptimismCanyonFlag = flags.BigFlag{
 		Name:  "override.canyon",
@@ -119,10 +127,6 @@ var (
 	OverrideOptimismEcotoneFlag = flags.BigFlag{
 		Name:  "override.ecotone",
 		Usage: "Manually specify the Optimism Ecotone fork time, overriding the bundled setting",
-	}
-	TrustedSetupFile = cli.StringFlag{
-		Name:  "trusted-setup-file",
-		Usage: "Absolute path to trusted_setup.json file",
 	}
 	// Ethash settings
 	EthashCachesInMemoryFlag = cli.IntFlag{

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -42,7 +42,7 @@ func VerifyEip1559Header(config *chain.Config, parent, header *types.Header, ski
 			parentGasLimit = parent.GasLimit * config.ElasticityMultiplier(params.ElasticityMultiplier)
 		}
 
-		if config.Optimism == nil {
+		if config.Optimism == nil { // gasLimit can adjust instantly in optimism
 			if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
 				return err
 			}

--- a/core/block_builder_parameters.go
+++ b/core/block_builder_parameters.go
@@ -16,9 +16,7 @@ type BlockBuilderParameters struct {
 	SuggestedFeeRecipient libcommon.Address
 	Withdrawals           []*types.Withdrawal // added in Shapella (EIP-4895)
 	ParentBeaconBlockRoot *libcommon.Hash     // added in Dencun (EIP-4788)
-
-	// Optimism additions
-	Deposits [][]byte
-	NoTxPool bool
-	GasLimit *uint64
+	Transactions          [][]byte
+	NoTxPool              bool
+	GasLimit              *uint64
 }

--- a/core/types/blob_tx_wrapper.go
+++ b/core/types/blob_tx_wrapper.go
@@ -343,8 +343,6 @@ func (txw *BlobTxWrapper) SetSender(address libcommon.Address) { txw.Tx.SetSende
 
 func (txw *BlobTxWrapper) IsContractDeploy() bool { return txw.Tx.IsContractDeploy() }
 
-func (txw *BlobTxWrapper) IsDepositTx() bool { return false }
-
 func (txw *BlobTxWrapper) Unwrap() Transaction { return &txw.Tx }
 
 func (txw *BlobTxWrapper) DecodeRLP(s *rlp.Stream) error {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -370,28 +370,15 @@ func (tx DepositTx) GetFeeCap() *uint256.Int { return uint256.NewInt(0) }
 
 // Is this needed at all?
 func (tx DepositTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
-	if baseFee == nil {
-		return tx.GetTip()
-	}
-	gasFeeCap := tx.GetFeeCap()
-	// return 0 because effectiveFee cant be < 0
-	if gasFeeCap.Lt(baseFee) {
-		return uint256.NewInt(0)
-	}
-	effectiveFee := new(uint256.Int).Sub(gasFeeCap, baseFee)
-	if tx.GetTip().Lt(effectiveFee) {
-		return tx.GetTip()
-	} else {
-		return effectiveFee
-	}
+	return uint256.NewInt(0)
 }
 
 func (tx DepositTx) Cost() *uint256.Int {
-	return tx.Value.Clone()
+	return tx.Value.Clone() // TODO(jky) evaluate correctness
 }
 
 func (tx DepositTx) GetAccessList() types2.AccessList {
-	return nil
+	return nil // TODO(jky) evaluate correctness vs an empty List
 }
 
 // NewDepositTransaction creates a deposit transaction

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -36,8 +36,8 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-// DepositTransaction is the transaction data of an Optimism Deposit Transaction
-type DepositTransaction struct {
+// DepositTx is the transaction data of an Optimism Deposit Transaction
+type DepositTx struct {
 	TransactionMisc
 
 	SourceHash *libcommon.Hash
@@ -50,39 +50,39 @@ type DepositTransaction struct {
 	Data       []byte
 }
 
-func (tx DepositTransaction) GetBlobGas() uint64      { return 0 } // FIXME - do we need this?
-func (tx DepositTransaction) GetGas() uint64          { return tx.GasLimit }
-func (tx DepositTransaction) GetPrice() *uint256.Int  { return uint256.NewInt(0) }
-func (tx DepositTransaction) GetTip() *uint256.Int    { return uint256.NewInt(0) }
-func (tx DepositTransaction) GetFeeCap() *uint256.Int { return uint256.NewInt(0) }
-func (tx DepositTransaction) GetNonce() uint64        { return 0 }
-func (tx DepositTransaction) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
+func (tx DepositTx) GetBlobGas() uint64      { return 0 } // FIXME - do we need this?
+func (tx DepositTx) GetGas() uint64          { return tx.GasLimit }
+func (tx DepositTx) GetPrice() *uint256.Int  { return uint256.NewInt(0) }
+func (tx DepositTx) GetTip() *uint256.Int    { return uint256.NewInt(0) }
+func (tx DepositTx) GetFeeCap() *uint256.Int { return uint256.NewInt(0) }
+func (tx DepositTx) GetNonce() uint64        { return 0 }
+func (tx DepositTx) GetEffectiveGasTip(baseFee *uint256.Int) *uint256.Int {
 	return uint256.NewInt(0)
 }
-func (tx *DepositTransaction) Unwrap() Transaction { return tx }
+func (tx *DepositTx) Unwrap() Transaction { return tx }
 
-func (tx DepositTransaction) Cost() *uint256.Int {
+func (tx DepositTx) Cost() *uint256.Int {
 	log.Error("Cost() called for a Deposit transaction")
 	total := new(uint256.Int)
 	return total
 }
 
-func (tx DepositTransaction) GetAccessList() types2.AccessList {
+func (tx DepositTx) GetAccessList() types2.AccessList {
 	return types2.AccessList{}
 }
-func (tx DepositTransaction) GetData() []byte {
+func (tx DepositTx) GetData() []byte {
 	return tx.Data
 }
-func (tx DepositTransaction) GetBlobHashes() []libcommon.Hash {
+func (tx DepositTx) GetBlobHashes() []libcommon.Hash {
 	// Only blob txs have data hashes
 	return []libcommon.Hash{}
 }
 
-func (tx DepositTransaction) Protected() bool {
+func (tx DepositTx) Protected() bool {
 	return true
 }
 
-func (tx DepositTransaction) EncodingSize() int {
+func (tx DepositTx) EncodingSize() int {
 	payloadSize := tx.payloadSize()
 	envelopeSize := payloadSize
 	// Add envelope size and type size
@@ -94,8 +94,8 @@ func (tx DepositTransaction) EncodingSize() int {
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
-func (tx DepositTransaction) copy() *DepositTransaction {
-	cpy := &DepositTransaction{
+func (tx DepositTx) copy() *DepositTx {
+	cpy := &DepositTx{
 		SourceHash: tx.SourceHash,
 		From:       tx.From,
 		To:         tx.To,
@@ -110,12 +110,12 @@ func (tx DepositTransaction) copy() *DepositTransaction {
 }
 
 // MarshalBinary returns the canonical encoding of the transaction.
-func (tx DepositTransaction) MarshalBinary(w io.Writer) error {
+func (tx DepositTx) MarshalBinary(w io.Writer) error {
 	return tx.EncodeRLP(w)
 }
 
 // EncodeRLP implements rlp.Encoder
-func (tx DepositTransaction) EncodeRLP(w io.Writer) error {
+func (tx DepositTx) EncodeRLP(w io.Writer) error {
 	var b [33]byte
 	rlp.EncodeInt(DepositTxType, w, b[:])
 
@@ -167,7 +167,7 @@ func (tx DepositTransaction) EncodeRLP(w io.Writer) error {
 	return nil
 }
 
-func (tx DepositTransaction) payloadSize() int {
+func (tx DepositTx) payloadSize() int {
 	// SourceHash
 	payloadSize := 1
 	payloadSize += len(tx.SourceHash)
@@ -215,7 +215,7 @@ func (tx DepositTransaction) payloadSize() int {
 }
 
 // DecodeRLP decodes DepositTransaction but with the list token already consumed and encodingSize being presented
-func (tx *DepositTransaction) DecodeRLP(s *rlp.Stream) error {
+func (tx *DepositTx) DecodeRLP(s *rlp.Stream) error {
 	var err error
 	var b []byte
 
@@ -281,7 +281,7 @@ func (tx *DepositTransaction) DecodeRLP(s *rlp.Stream) error {
 }
 
 // AsMessage returns the transaction as a core.Message.
-func (tx DepositTransaction) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (Message, error) {
+func (tx DepositTx) AsMessage(s Signer, _ *big.Int, rules *chain.Rules) (Message, error) {
 	msg := Message{
 		txType:     DepositTxType,
 		sourceHash: tx.SourceHash,
@@ -298,24 +298,24 @@ func (tx DepositTransaction) AsMessage(s Signer, _ *big.Int, rules *chain.Rules)
 	return msg, nil
 }
 
-func (tx *DepositTransaction) WithSignature(signer Signer, sig []byte) (Transaction, error) {
+func (tx *DepositTx) WithSignature(signer Signer, sig []byte) (Transaction, error) {
 	log.Error("WithSignature() called for a Deposit transaction")
 	cpy := tx.copy()
 	return cpy, nil
 }
 
-func (tx *DepositTransaction) FakeSign(address libcommon.Address) (Transaction, error) {
+func (tx *DepositTx) FakeSign(address libcommon.Address) (Transaction, error) {
 	log.Error("FakeSign() called for a Deposit transaction")
 	cpy := tx.copy()
 	return cpy, nil
 }
 
-func (tx DepositTransaction) RollupCostData() types2.RollupCostData {
+func (tx DepositTx) RollupCostData() types2.RollupCostData {
 	return types2.RollupCostData{}
 }
 
 // Hash computes the hash (but not for signatures!)
-func (tx *DepositTransaction) Hash() libcommon.Hash {
+func (tx *DepositTx) Hash() libcommon.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash.(*libcommon.Hash)
 	}
@@ -337,49 +337,49 @@ func (tx *DepositTransaction) Hash() libcommon.Hash {
 
 }
 
-func (tx DepositTransaction) SigningHash(chainID *big.Int) libcommon.Hash {
+func (tx DepositTx) SigningHash(chainID *big.Int) libcommon.Hash {
 	log.Error("SigningHash() called for a Deposit transaction")
 	return libcommon.Hash{}
 }
 
-func (tx DepositTransaction) Type() byte { return DepositTxType }
+func (tx DepositTx) Type() byte { return DepositTxType }
 
-func (tx DepositTransaction) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
+func (tx DepositTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.Int) {
 	log.Error("SigningHash() called for a Deposit transaction")
 	return uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0)
 }
 
-func (tx DepositTransaction) GetChainID() *uint256.Int {
+func (tx DepositTx) GetChainID() *uint256.Int {
 	log.Error("GetChainID() called for a Deposit transaction")
 	return new(uint256.Int)
 }
-func (tx DepositTransaction) GetSender() (libcommon.Address, bool) {
+func (tx DepositTx) GetSender() (libcommon.Address, bool) {
 	return *tx.From, true
 }
-func (tx DepositTransaction) GetTo() *libcommon.Address {
+func (tx DepositTx) GetTo() *libcommon.Address {
 	return tx.To
 }
 
-func (tx DepositTransaction) GetValue() *uint256.Int {
+func (tx DepositTx) GetValue() *uint256.Int {
 	return tx.Value
 }
 
-func (tx DepositTransaction) IsContractDeploy() bool {
+func (tx DepositTx) IsContractDeploy() bool {
 	return tx.GetTo() == nil
 }
 
-func (tx DepositTransaction) IsDepositTx() bool {
+func (tx DepositTx) IsDepositTx() bool {
 	return true
 }
 
-func (tx DepositTransaction) IsStarkNet() bool {
+func (tx DepositTx) IsStarkNet() bool {
 	return false
 }
 
-func (tx *DepositTransaction) Sender(signer Signer) (libcommon.Address, error) {
+func (tx *DepositTx) Sender(signer Signer) (libcommon.Address, error) {
 	return *tx.From, nil
 }
-func (tx *DepositTransaction) SetSender(addr libcommon.Address) {
+func (tx *DepositTx) SetSender(addr libcommon.Address) {
 	if tx.From != nil && *tx.From != addr {
 		log.Error("SetSender() address confict for Deposit transaction", "old", tx.From, "new", addr)
 	}

--- a/core/types/deposit_tx_test.go
+++ b/core/types/deposit_tx_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDepositTxHash(t *testing.T) {
-	dtx := DepositTransaction{
+	dtx := DepositTx{
 		SourceHash: ptr(common.HexToHash("0xc9fa17cc88928d8303f4efcc0053ddbd8c5baea5ed4c1da2efd019833070c182")),
 		From:       ptr(common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9")),
 		To:         ptr(common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9")),

--- a/core/types/deposit_tx_test.go
+++ b/core/types/deposit_tx_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestDepositTxHash(t *testing.T) {
 	dtx := DepositTx{
-		SourceHash: ptr(common.HexToHash("0xc9fa17cc88928d8303f4efcc0053ddbd8c5baea5ed4c1da2efd019833070c182")),
-		From:       ptr(common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9")),
+		SourceHash: common.HexToHash("0xc9fa17cc88928d8303f4efcc0053ddbd8c5baea5ed4c1da2efd019833070c182"),
+		From:       common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9"),
 		To:         ptr(common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9")),
 		Mint:       uint256.NewInt(1_000_000_000_000),
 		Value:      uint256.NewInt(0),

--- a/core/types/deposit_tx_test.go
+++ b/core/types/deposit_tx_test.go
@@ -15,7 +15,7 @@ func TestDepositTxHash(t *testing.T) {
 		To:         ptr(common.HexToAddress("0x976EA74026E726554dB657fA54763abd0C3a0aa9")),
 		Mint:       uint256.NewInt(1_000_000_000_000),
 		Value:      uint256.NewInt(0),
-		GasLimit:   1_000_000,
+		Gas:        1_000_000,
 	}
 
 	require.Equal(t, common.HexToHash("0x5c7753e59abb0904e0e70a28f4d24458cf20c2b5b491365411ce54a662874197"), dtx.Hash())

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -464,8 +464,6 @@ func NewEIP1559Transaction(chainID uint256.Int, nonce uint64, to libcommon.Addre
 	}
 }
 
-func (tx *DynamicFeeTransaction) IsDepositTx() bool { return false }
-
 func (tx *DynamicFeeTransaction) RollupCostData() types2.RollupCostData {
 	return tx.computeRollupGas(tx)
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -86,11 +86,6 @@ func (ct CommonTx) IsContractDeploy() bool {
 	return ct.GetTo() == nil
 }
 
-// IsDepositTx returns true if the transaction is a deposit tx type.
-func (ct CommonTx) IsDepositTx() bool {
-	return false
-}
-
 func (ct *CommonTx) GetBlobHashes() []libcommon.Hash {
 	// Only blob txs have blob hashes
 	return []libcommon.Hash{}

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -345,12 +345,12 @@ func TestDeriveFields(t *testing.T) {
 				GasPrice: uint256.NewInt(3),
 			},
 		},
-		&DepositTransaction{
+		&DepositTx{
 			Value:    uint256.NewInt(3),
 			From:     &libcommon.Address{},
 			GasLimit: 4,
 		},
-		&DepositTransaction{
+		&DepositTx{
 			From:     &libcommon.Address{},
 			To:       nil, // contract creation
 			Value:    uint256.NewInt(6),
@@ -746,7 +746,7 @@ func getOptimismTxReceipts(
 	//to4 := common.HexToAddress("0x4")
 	// Create a few transactions to have receipts for
 	txs := Transactions{
-		&DepositTransaction{
+		&DepositTx{
 			To:       nil, // contract creation
 			Value:    uint256.NewInt(6),
 			GasLimit: 50,

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -346,15 +346,15 @@ func TestDeriveFields(t *testing.T) {
 			},
 		},
 		&DepositTx{
-			Value:    uint256.NewInt(3),
-			From:     libcommon.Address{},
-			GasLimit: 4,
+			Value: uint256.NewInt(3),
+			From:  libcommon.Address{},
+			Gas:   4,
 		},
 		&DepositTx{
-			From:     libcommon.Address{},
-			To:       nil, // contract creation
-			Value:    uint256.NewInt(6),
-			GasLimit: 5,
+			From:  libcommon.Address{},
+			To:    nil, // contract creation
+			Value: uint256.NewInt(6),
+			Gas:   5,
 		},
 	}
 	depNonce := uint64(7)
@@ -747,10 +747,10 @@ func getOptimismTxReceipts(
 	// Create a few transactions to have receipts for
 	txs := Transactions{
 		&DepositTx{
-			To:       nil, // contract creation
-			Value:    uint256.NewInt(6),
-			GasLimit: 50,
-			Data:     l1AttributesPayload,
+			To:    nil, // contract creation
+			Value: uint256.NewInt(6),
+			Gas:   50,
+			Data:  l1AttributesPayload,
 		},
 		emptyTx,
 	}

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -347,11 +347,11 @@ func TestDeriveFields(t *testing.T) {
 		},
 		&DepositTx{
 			Value:    uint256.NewInt(3),
-			From:     &libcommon.Address{},
+			From:     libcommon.Address{},
 			GasLimit: 4,
 		},
 		&DepositTx{
-			From:     &libcommon.Address{},
+			From:     libcommon.Address{},
 			To:       nil, // contract creation
 			Value:    uint256.NewInt(6),
 			GasLimit: 5,

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -563,7 +563,6 @@ func (t *TransactionsFixedOrder) Pop() {
 // Message is a fully derived transaction and implements core.Message
 type Message struct {
 	txType           byte
-	sourceHash       *libcommon.Hash // TODO(jky) Why is this here?
 	to               *libcommon.Address
 	from             libcommon.Address
 	nonce            uint64

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -250,7 +250,7 @@ func UnmarshalTransactionFromBinary(data []byte) (Transaction, error) {
 		return t, nil
 	case DepositTxType:
 		s := rlp.NewStream(bytes.NewReader(data[1:]), uint64(len(data)-1))
-		t := &DepositTransaction{}
+		t := &DepositTx{}
 		if err := t.DecodeRLP(s); err != nil {
 			return nil, err
 		}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/ledgerwatch/erigon-lib/common/hexutil"
 
 	"github.com/holiman/uint256"
@@ -112,7 +113,7 @@ func (tx DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
-func (tx DepositTransaction) MarshalJSON() ([]byte, error) {
+func (tx DepositTx) MarshalJSON() ([]byte, error) {
 	var enc txJSON
 	// These are set for all tx types.
 	enc.Hash = tx.Hash()
@@ -202,7 +203,7 @@ func UnmarshalTransactionFromJSON(input []byte) (Transaction, error) {
 		}
 		return tx, nil
 	case DepositTxType:
-		tx := &DepositTransaction{}
+		tx := &DepositTx{}
 		if err = tx.UnmarshalJSON(input); err != nil {
 			return nil, err
 		}
@@ -445,7 +446,7 @@ func (tx *DynamicFeeTransaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *DepositTransaction) UnmarshalJSON(input []byte) error {
+func (tx *DepositTx) UnmarshalJSON(input []byte) error {
 	var dec txJSON
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -123,12 +123,12 @@ func (tx DepositTx) MarshalJSON() ([]byte, error) {
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutility.Bytes)(&tx.Data)
 	enc.To = tx.To
-	enc.SourceHash = tx.SourceHash
-	enc.From = tx.From
+	enc.SourceHash = &tx.SourceHash
+	enc.From = &tx.From
 	if tx.Mint != nil {
 		enc.Mint = (*hexutil.Big)(tx.Mint.ToBig())
 	}
-	enc.IsSystemTx = &tx.IsSystemTx
+	enc.IsSystemTx = &tx.IsSystemTransaction
 	// other fields will show up as null.
 	return json.Marshal(&enc)
 }
@@ -486,14 +486,14 @@ func (tx *DepositTx) UnmarshalJSON(input []byte) error {
 	if dec.From == nil {
 		return errors.New("missing required field 'from' in transaction")
 	}
-	tx.From = dec.From
+	tx.From = *dec.From
 	if dec.SourceHash == nil {
 		return errors.New("missing required field 'sourceHash' in transaction")
 	}
-	tx.SourceHash = dec.SourceHash
+	tx.SourceHash = *dec.SourceHash
 	// IsSystemTx may be omitted. Defaults to false.
 	if dec.IsSystemTx != nil {
-		tx.IsSystemTx = *dec.IsSystemTx
+		tx.IsSystemTransaction = *dec.IsSystemTx
 	}
 	// nonce is not checked becaues depositTx has no nonce field.
 	return nil

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -119,7 +119,7 @@ func (tx DepositTx) MarshalJSON() ([]byte, error) {
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.ChainID = (*hexutil.Big)(libcommon.Big0)
-	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
+	enc.Gas = (*hexutil.Uint64)(&tx.Gas)
 	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
 	enc.Data = (*hexutility.Bytes)(&tx.Data)
 	enc.To = tx.To
@@ -465,7 +465,7 @@ func (tx *DepositTx) UnmarshalJSON(input []byte) error {
 	if dec.To != nil {
 		tx.To = dec.To
 	}
-	tx.GasLimit = uint64(*dec.Gas)
+	tx.Gas = uint64(*dec.Gas)
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -268,7 +268,7 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, tx Transaction) (
 		// id, add 27 to become equivalent to unprotected Homestead signatures.
 		V.Add(&t.V, u256.Num27)
 		R, S = &t.R, &t.S
-	case *DepositTransaction:
+	case *DepositTx:
 		// This type contains an explicit From: field
 		sender, _ := tx.GetSender()
 		return sender, nil
@@ -311,7 +311,7 @@ func (sg Signer) SignatureValues(tx Transaction, sig []byte) (R, S, V *uint256.I
 			return nil, nil, nil, ErrInvalidChainId
 		}
 		R, S, V = decodeSignature(sig)
-	case *DepositTransaction:
+	case *DepositTx:
 		return nil, nil, nil, fmt.Errorf("deposits do not have a signature")
 	default:
 		return nil, nil, nil, ErrTxTypeNotSupported

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -207,7 +207,7 @@ func SpawnMiningCreateBlockStage(s *StageState, tx kv.RwTx, cfg MiningCreateBloc
 		current.Uncles = nil
 		current.Withdrawals = cfg.blockBuilderParameters.Withdrawals
 
-		current.Deposits = cfg.blockBuilderParameters.Deposits
+		current.Deposits = cfg.blockBuilderParameters.Transactions
 		current.NoTxPool = cfg.blockBuilderParameters.NoTxPool
 		return nil
 	}

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -489,7 +489,7 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.GasPrice = computeGasPrice(tx, blockHash, baseFee)
 		result.MaxFeePerBlobGas = (*hexutil.Big)(t.MaxFeePerBlobGas.ToBig())
 		result.BlobVersionedHashes = t.GetBlobHashes()
-	case *types.DepositTransaction:
+	case *types.DepositTx:
 		result.SourceHash = t.SourceHash
 		if t.IsSystemTx {
 			result.IsSystemTx = t.IsSystemTx

--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -490,9 +490,9 @@ func newRPCTransaction(tx types.Transaction, blockHash libcommon.Hash, blockNumb
 		result.MaxFeePerBlobGas = (*hexutil.Big)(t.MaxFeePerBlobGas.ToBig())
 		result.BlobVersionedHashes = t.GetBlobHashes()
 	case *types.DepositTx:
-		result.SourceHash = t.SourceHash
-		if t.IsSystemTx {
-			result.IsSystemTx = t.IsSystemTx
+		result.SourceHash = &t.SourceHash
+		if t.IsSystemTransaction {
+			result.IsSystemTx = t.IsSystemTransaction
 		}
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)

--- a/turbo/adapter/ethapi/api_test.go
+++ b/turbo/adapter/ethapi/api_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewRPCTransactionDepositTx(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		SourceHash: &libcommon.Hash{1},
 		From:       &libcommon.Address{1},
 		IsSystemTx: true,
@@ -38,7 +38,7 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 }
 
 func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		SourceHash: &libcommon.Hash{1},
 		From:       &libcommon.Address{1},
 		IsSystemTx: true,
@@ -75,7 +75,7 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 }
 
 func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		IsSystemTx: false,
 		From:       &libcommon.Address{1},
 		Value:      uint256.NewInt(1337),
@@ -155,7 +155,7 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tx := &types.DepositTransaction{
+			tx := &types.DepositTx{
 				SourceHash: &libcommon.Hash{1},
 				From:       &libcommon.Address{1},
 				IsSystemTx: true,
@@ -166,7 +166,7 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 			test.modifier(rpcTx)
 			json, err := json.Marshal(rpcTx)
 			require.NoError(t, err, "marshalling failed: %w", err)
-			parsed := &types.DepositTransaction{}
+			parsed := &types.DepositTx{}
 			err = parsed.UnmarshalJSON(json)
 			if test.valid {
 				require.NoError(t, err, "unmarshal failed: %w", err)

--- a/turbo/adapter/ethapi/api_test.go
+++ b/turbo/adapter/ethapi/api_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestNewRPCTransactionDepositTx(t *testing.T) {
 	tx := &types.DepositTx{
-		SourceHash: &libcommon.Hash{1},
-		From:       &libcommon.Address{1},
-		IsSystemTx: true,
-		Mint:       uint256.NewInt(34),
-		Value:      uint256.NewInt(1337),
+		SourceHash:          libcommon.Hash{1},
+		From:                libcommon.Address{1},
+		IsSystemTransaction: true,
+		Mint:                uint256.NewInt(34),
+		Value:               uint256.NewInt(1337),
 	}
 	nonce := uint64(12)
 	depositNonce := &nonce
@@ -31,19 +31,19 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().S = %v, want 0x0", got.S)
 
 	// Should include deposit tx specific fields
-	require.Equal(t, got.SourceHash, tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
-	require.Equal(t, got.IsSystemTx, tx.IsSystemTx, "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx)
+	require.Equal(t, got.SourceHash, &tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
+	require.Equal(t, got.IsSystemTx, tx.IsSystemTransaction, "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
 	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Mint = %v, want %v", got.Nonce, nonce)
 }
 
 func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 	tx := &types.DepositTx{
-		SourceHash: &libcommon.Hash{1},
-		From:       &libcommon.Address{1},
-		IsSystemTx: true,
-		Mint:       uint256.NewInt(34),
-		Value:      uint256.NewInt(1337),
+		SourceHash:          libcommon.Hash{1},
+		From:                libcommon.Address{1},
+		IsSystemTransaction: true,
+		Mint:                uint256.NewInt(34),
+		Value:               uint256.NewInt(1337),
 	}
 	nonce := uint64(7)
 	version := types.CanyonDepositReceiptVersion
@@ -59,8 +59,8 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().S = %v, want 0x0", got.S)
 
 	// Should include versioned deposit tx specific fields
-	require.Equal(t, got.SourceHash, tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
-	require.Equal(t, got.IsSystemTx, tx.IsSystemTx, "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx)
+	require.Equal(t, got.SourceHash, &tx.SourceHash, "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
+	require.Equal(t, got.IsSystemTx, tx.IsSystemTransaction, "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
 	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Nonce = %v, want %v", got.Nonce, nonce)
 	require.Equal(t, *got.DepositReceiptVersion, (hexutil.Uint64(version)), "newRPCTransaction().DepositReceiptVersion = %v, want %v", *got.DepositReceiptVersion, version)
@@ -76,9 +76,9 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 
 func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
 	tx := &types.DepositTx{
-		IsSystemTx: false,
-		From:       &libcommon.Address{1},
-		Value:      uint256.NewInt(1337),
+		IsSystemTransaction: false,
+		From:                libcommon.Address{1},
+		Value:               uint256.NewInt(1337),
 	}
 	got := newRPCTransaction(tx, libcommon.Hash{}, uint64(12), uint64(1), big.NewInt(0), nil)
 
@@ -156,11 +156,11 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tx := &types.DepositTx{
-				SourceHash: &libcommon.Hash{1},
-				From:       &libcommon.Address{1},
-				IsSystemTx: true,
-				Mint:       uint256.NewInt(34),
-				Value:      uint256.NewInt(1337),
+				SourceHash:          libcommon.Hash{1},
+				From:                libcommon.Address{1},
+				IsSystemTransaction: true,
+				Mint:                uint256.NewInt(34),
+				Value:               uint256.NewInt(1337),
 			}
 			rpcTx := newRPCTransaction(tx, libcommon.Hash{}, uint64(12), uint64(1), big.NewInt(0), nil)
 			test.modifier(rpcTx)

--- a/turbo/execution/eth1/block_building.go
+++ b/turbo/execution/eth1/block_building.go
@@ -54,7 +54,7 @@ func (e *EthereumExecutionModule) AssembleBlock(ctx context.Context, req *execut
 		PrevRandao:            gointerfaces.ConvertH256ToHash(req.PrevRandao),
 		SuggestedFeeRecipient: gointerfaces.ConvertH160toAddress(req.SuggestedFeeRecipient),
 		Withdrawals:           eth1_utils.ConvertWithdrawalsFromRpc(req.Withdrawals),
-		Deposits:              req.Transactions,
+		Transactions:          req.Transactions,
 		NoTxPool:              req.NoTxPool,
 		GasLimit:              req.GasLimit,
 	}

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -464,9 +464,9 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.MaxFeePerBlobGas = (*hexutil.Big)(t.MaxFeePerBlobGas.ToBig())
 		result.BlobVersionedHashes = t.BlobVersionedHashes
 	case *types.DepositTx:
-		result.SourceHash = t.SourceHash
-		if t.IsSystemTx {
-			result.IsSystemTx = t.IsSystemTx
+		result.SourceHash = &t.SourceHash
+		if t.IsSystemTransaction {
+			result.IsSystemTx = t.IsSystemTransaction
 		}
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)

--- a/turbo/jsonrpc/eth_api.go
+++ b/turbo/jsonrpc/eth_api.go
@@ -463,7 +463,7 @@ func NewRPCTransaction(tx types.Transaction, blockHash common.Hash, blockNumber 
 		result.GasPrice = computeGasPrice(tx, blockHash, baseFee)
 		result.MaxFeePerBlobGas = (*hexutil.Big)(t.MaxFeePerBlobGas.ToBig())
 		result.BlobVersionedHashes = t.BlobVersionedHashes
-	case *types.DepositTransaction:
+	case *types.DepositTx:
 		result.SourceHash = t.SourceHash
 		if t.IsSystemTx {
 			result.IsSystemTx = t.IsSystemTx

--- a/turbo/jsonrpc/eth_api_test.go
+++ b/turbo/jsonrpc/eth_api_test.go
@@ -242,7 +242,7 @@ func TestCall_ByBlockHash_WithRequireCanonicalTrue_NonCanonicalBlock(t *testing.
 }
 
 func TestNewRPCTransactionDepositTx(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		SourceHash: &common.Hash{1},
 		From:       &common.Address{1},
 		IsSystemTx: true,
@@ -267,7 +267,7 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 }
 
 func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		SourceHash: &common.Hash{1},
 		From:       &common.Address{1},
 		IsSystemTx: true,
@@ -304,7 +304,7 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 }
 
 func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
-	tx := &types.DepositTransaction{
+	tx := &types.DepositTx{
 		IsSystemTx: false,
 		From:       &common.Address{1},
 		Value:      uint256.NewInt(1337),
@@ -384,7 +384,7 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tx := &types.DepositTransaction{
+			tx := &types.DepositTx{
 				SourceHash: &common.Hash{1},
 				From:       &common.Address{1},
 				IsSystemTx: true,
@@ -395,7 +395,7 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 			test.modifier(rpcTx)
 			json, err := json.Marshal(rpcTx)
 			require.NoError(t, err, "marshalling failed: %w", err)
-			parsed := &types.DepositTransaction{}
+			parsed := &types.DepositTx{}
 			err = parsed.UnmarshalJSON(json)
 			if test.valid {
 				require.NoError(t, err, "unmarshal failed: %w", err)

--- a/turbo/jsonrpc/eth_api_test.go
+++ b/turbo/jsonrpc/eth_api_test.go
@@ -243,11 +243,11 @@ func TestCall_ByBlockHash_WithRequireCanonicalTrue_NonCanonicalBlock(t *testing.
 
 func TestNewRPCTransactionDepositTx(t *testing.T) {
 	tx := &types.DepositTx{
-		SourceHash: &common.Hash{1},
-		From:       &common.Address{1},
-		IsSystemTx: true,
-		Mint:       uint256.NewInt(34),
-		Value:      uint256.NewInt(1337),
+		SourceHash:          common.Hash{1},
+		From:                common.Address{1},
+		IsSystemTransaction: true,
+		Mint:                uint256.NewInt(34),
+		Value:               uint256.NewInt(1337),
 	}
 	nonce := uint64(12)
 	depositNonce := &nonce
@@ -260,19 +260,19 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "NewRPCTransaction().S = %v, want 0x0", got.S)
 
 	// Should include deposit tx specific fields
-	require.Equal(t, got.SourceHash, tx.SourceHash, "NewRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
-	require.Equal(t, got.IsSystemTx, tx.IsSystemTx, "NewRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx)
+	require.Equal(t, got.SourceHash, &tx.SourceHash, "NewRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
+	require.Equal(t, got.IsSystemTx, tx.IsSystemTransaction, "NewRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "NewRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
 	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "NewRPCTransaction().Nonce = %v, want %v", got.Nonce, nonce)
 }
 
 func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 	tx := &types.DepositTx{
-		SourceHash: &common.Hash{1},
-		From:       &common.Address{1},
-		IsSystemTx: true,
-		Mint:       uint256.NewInt(34),
-		Value:      uint256.NewInt(1337),
+		SourceHash:          common.Hash{1},
+		From:                common.Address{1},
+		IsSystemTransaction: true,
+		Mint:                uint256.NewInt(34),
+		Value:               uint256.NewInt(1337),
 	}
 	nonce := uint64(7)
 	version := types.CanyonDepositReceiptVersion
@@ -288,8 +288,8 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "NewRPCTransaction().S = %v, want 0x0", got.S)
 
 	// Should include versioned deposit tx specific fields
-	require.Equal(t, got.SourceHash, tx.SourceHash, "NewRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
-	require.Equal(t, got.IsSystemTx, tx.IsSystemTx, "NewRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx)
+	require.Equal(t, got.SourceHash, &tx.SourceHash, "NewRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash)
+	require.Equal(t, got.IsSystemTx, tx.IsSystemTransaction, "NewRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTransaction)
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint.ToBig()), "NewRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint.ToBig())
 	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "NewRPCTransaction().Nonce = %v, want %v", got.Nonce, nonce)
 	require.Equal(t, *got.DepositReceiptVersion, (hexutil.Uint64(version)), "NewRPCTransaction().DepositReceiptVersion = %v, want %v", *got.DepositReceiptVersion, version)
@@ -305,9 +305,9 @@ func TestNewRPCTransactionDepositTxWithVersion(t *testing.T) {
 
 func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
 	tx := &types.DepositTx{
-		IsSystemTx: false,
-		From:       &common.Address{1},
-		Value:      uint256.NewInt(1337),
+		IsSystemTransaction: false,
+		From:                common.Address{1},
+		Value:               uint256.NewInt(1337),
 	}
 	got := NewRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), nil)
 
@@ -385,11 +385,11 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tx := &types.DepositTx{
-				SourceHash: &common.Hash{1},
-				From:       &common.Address{1},
-				IsSystemTx: true,
-				Mint:       uint256.NewInt(34),
-				Value:      uint256.NewInt(1337),
+				SourceHash:          common.Hash{1},
+				From:                common.Address{1},
+				IsSystemTransaction: true,
+				Mint:                uint256.NewInt(34),
+				Value:               uint256.NewInt(1337),
 			}
 			rpcTx := NewRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), nil)
 			test.modifier(rpcTx)

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -747,7 +747,7 @@ func marshalReceipt(receipt *types.Receipt, txn types.Transaction, chainConfig *
 		if t.Protected() {
 			chainId = types.DeriveChainId(&t.V).ToBig()
 		}
-	case *types.DepositTransaction:
+	case *types.DepositTx:
 		chainId = chainConfig.ChainID
 	default:
 		chainId = txn.GetChainID().ToBig()


### PR DESCRIPTION
This PR is trying to identify deviations in our op-erigon from the testinprod/op-erigon codebase.  They were developed in parallel, but both based on the op-geth changes so much of things are pretty similar.  Still, field ordering, abbreviations, etc. are different which create merge conflicts and make it hard for our two forks to share work.

This is the first part of an effort to align our two forks so that work can be shared more easily.