### PR TITLE
Update superchain-registry package

### DIFF
--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -41,7 +41,7 @@ func TestGenesisBlockHashes(t *testing.T) {
 		require.Equal(t, block.Hash().Bytes(), expect.Bytes(), network)
 	}
 	for _, network := range networkname.All {
-		if network == "optimism-mainnet" || network == "boba-sepolia" {
+		if network == "op-mainnet" || network == "boba-sepolia" {
 			t.Skip()
 		}
 		check(network)

--- a/erigon-lib/chain/networkname/network_name.go
+++ b/erigon-lib/chain/networkname/network_name.go
@@ -23,8 +23,6 @@ const (
 	LegacyOPMainnetChainName = "optimism-mainnet"
 	LegacyOPGoerliChainName  = "optimism-goerli"
 	LegacyOPSepoliaChainName = "optimism-sepolia"
-
-	BobaSepoliaSuperchainName = "boba-boba-sepolia"
 )
 
 var All = []string{
@@ -54,15 +52,6 @@ func HandleLegacyName(name string) string {
 		return OPSepoliaChainName
 	case LegacyOPMainnetChainName:
 		return OPMainnetChainName
-	default:
-		return name
-	}
-}
-
-func HandleBobaSuperchainName(name string) string {
-	switch name {
-	case BobaSepoliaChainName:
-		return BobaSepoliaSuperchainName
 	default:
 		return name
 	}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/emicklei/dot v1.6.0
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240201223137-d57c2429e4fc
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240315155522-09647974da0d
 	github.com/fjl/gencodec v0.0.0-20220412091415-8bb9e558978c
 	github.com/gballet/go-verkle v0.0.0-20221121182333-31427a1f2d35
 	github.com/gfx-labs/sse v0.0.0-20231226060816-f747e26a9baa

--- a/go.mod
+++ b/go.mod
@@ -302,4 +302,4 @@ replace github.com/ledgerwatch/erigon-lib => ./erigon-lib
 
 replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.12
 
-replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240223212802-3cf921f7ab5c
+replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240315201409-1ecd6fec327e

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHlV4j7NEo=
 github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240223212802-3cf921f7ab5c h1:IU4ydQNQcDZTms37yPy97jinnOgQ6fTvkd5Dgzz24Dw=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240223212802-3cf921f7ab5c/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240315201409-1ecd6fec327e h1:GdD5nhXwsA9sPAEEL//phSgwlWGo2vWFsN7XeTTQ78k=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240315201409-1ecd6fec327e/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/iter v0.0.0-20140124041915-454541ec3da2/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=
 github.com/bradfitz/iter v0.0.0-20190303215204-33e6a9893b0c/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -132,7 +132,7 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 	}
 
 	if opStackChainCfg.CanyonTime != nil {
-		out.ShanghaiTime = new(big.Int).SetUint64(*opStackChainCfg.CanyonTime) // Shanghai activates with Shanghai
+		out.ShanghaiTime = new(big.Int).SetUint64(*opStackChainCfg.CanyonTime) // Shanghai activates with Canyon
 		out.CanyonTime = new(big.Int).SetUint64(*opStackChainCfg.CanyonTime)
 	}
 	if opStackChainCfg.EcotoneTime != nil {

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -46,8 +46,6 @@ var (
 func OPStackChainConfigByName(name string) *superchain.ChainConfig {
 	// Handle legacy name aliases
 	name = networkname.HandleLegacyName(name)
-	// Handle Boba superchain name
-	name = networkname.HandleBobaSuperchainName(name)
 	for _, chainCfg := range superchain.OPChains {
 		if strings.EqualFold(chainCfg.Chain+"-"+chainCfg.Superchain, name) {
 			return chainCfg
@@ -133,13 +131,13 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		},
 	}
 
-	if superchainConfig.Config.CanyonTime != nil {
-		out.ShanghaiTime = new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime) // Shanghai activates with Canyon
-		out.CanyonTime = new(big.Int).SetUint64(*superchainConfig.Config.CanyonTime)
+	if opStackChainCfg.CanyonTime != nil {
+		out.ShanghaiTime = new(big.Int).SetUint64(*opStackChainCfg.CanyonTime) // Shanghai activates with Shanghai
+		out.CanyonTime = new(big.Int).SetUint64(*opStackChainCfg.CanyonTime)
 	}
-	if superchainConfig.Config.EcotoneTime != nil {
-		out.CancunTime = new(big.Int).SetUint64(*superchainConfig.Config.EcotoneTime) // CancunTime activates with Ecotone
-		out.EcotoneTime = new(big.Int).SetUint64(*superchainConfig.Config.EcotoneTime)
+	if opStackChainCfg.EcotoneTime != nil {
+		out.CancunTime = new(big.Int).SetUint64(*opStackChainCfg.EcotoneTime) // CancunTime activates with Ecotone
+		out.EcotoneTime = new(big.Int).SetUint64(*opStackChainCfg.EcotoneTime)
 	}
 
 	// note: no actual parameters are being loaded, yet.


### PR DESCRIPTION
This PR updates the `superchain-registry` package to `https://github.com/bobanetwork/superchain-registry/tree/0964797`. The new `superchain-registry` supports customized hardfork times, so some unnecessary code has been removed.