### PR TITLE
Change the datatype used for the "stateDiff" override to eth_call

### DIFF
--- a/turbo/adapter/ethapi/api.go
+++ b/turbo/adapter/ethapi/api.go
@@ -165,11 +165,11 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *uint256.Int) (type
 // if statDiff is set, all diff will be applied first and then execute the call
 // message.
 type Account struct {
-	Nonce     *hexutil.Uint64                 `json:"nonce"`
-	Code      *hexutility.Bytes               `json:"code"`
-	Balance   **hexutil.Big                   `json:"balance"`
-	State     *map[libcommon.Hash]uint256.Int `json:"state"`
-	StateDiff *map[libcommon.Hash]uint256.Int `json:"stateDiff"`
+	Nonce     *hexutil.Uint64                    `json:"nonce"`
+	Code      *hexutility.Bytes                  `json:"code"`
+	Balance   **hexutil.Big                      `json:"balance"`
+	State     *map[libcommon.Hash]uint256.Int    `json:"state"`
+	StateDiff *map[libcommon.Hash]libcommon.Hash `json:"stateDiff"`
 }
 
 func NewRevertError(result *core.ExecutionResult) *RevertError {

--- a/turbo/adapter/ethapi/state_overrides.go
+++ b/turbo/adapter/ethapi/state_overrides.go
@@ -8,6 +8,7 @@ import (
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 
 	"github.com/ledgerwatch/erigon/core/state"
+	"github.com/ledgerwatch/log/v3"
 )
 
 type StateOverrides map[libcommon.Address]Account
@@ -41,6 +42,7 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 		// Apply state diff into specified accounts.
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
+				log.Info("StateDiff override at", "addr", addr, "key", key, "value", value);
 				key := key
 				intValue := new(uint256.Int).SetBytes32(value.Bytes())
 				state.SetState(addr, &key, *intValue)

--- a/turbo/adapter/ethapi/state_overrides.go
+++ b/turbo/adapter/ethapi/state_overrides.go
@@ -42,7 +42,8 @@ func (overrides *StateOverrides) Override(state *state.IntraBlockState) error {
 		if account.StateDiff != nil {
 			for key, value := range *account.StateDiff {
 				key := key
-				state.SetState(addr, &key, value)
+				intValue := new(uint256.Int).SetBytes32(value.Bytes())
+				state.SetState(addr, &key, *intValue)
 			}
 		}
 	}


### PR DESCRIPTION
Change the datatype used for the "stateDiff" override to eth_call to a hash instead of a uint256.
 Needed for rundler-hc account abstraction, which is expecting geth behaviour.

 Changes to be committed:
	modified:   turbo/adapter/ethapi/api.go
	modified:   turbo/adapter/ethapi/state_overrides.go
