### PR TITLE
Update superchain registry to 2cc1ec0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -302,4 +302,4 @@ replace github.com/ledgerwatch/erigon-lib => ./erigon-lib
 
 replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.12
 
-replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240417003925-0d5b52881f48
+replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240605155641-2cc1ec002da8

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHlV4j7NEo=
 github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240417003925-0d5b52881f48 h1:nQRsX8jVFcJm+ujIsjvArLAgRLb1CrE6Hww0Y9yES1E=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240417003925-0d5b52881f48/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240605155641-2cc1ec002da8 h1:IKmpARKUiDMCChGeoJOXs8zD/h3fILANfhodpGaR0rk=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240605155641-2cc1ec002da8/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/iter v0.0.0-20140124041915-454541ec3da2/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=
 github.com/bradfitz/iter v0.0.0-20190303215204-33e6a9893b0c/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=


### PR DESCRIPTION
Update superchain-registry repo to 2cc1ec0

https://github.com/bobanetwork/superchain-registry/tree/0964797