### PR TITLE
Enable Fjord hardfork on testnets

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -841,8 +841,6 @@ func loadOPStackGenesisByChainName(name string) (*types.Genesis, error) {
 		switch opStackChainCfg.ChainID {
 		case params.OPMainnetChainID:
 			expectedHash = params.OPMainnetGenesisHash
-		case params.OPGoerliChainID:
-			expectedHash = params.OPGoerliGenesisHash
 		case params.BobaMainnetChainID:
 			expectedHash = params.BobaMainnetGenesisHash
 		case params.BobaSepoliaChainID:

--- a/erigon-lib/chain/networkname/network_name.go
+++ b/erigon-lib/chain/networkname/network_name.go
@@ -15,14 +15,12 @@ const (
 	ChiadoChainName         = "chiado"
 
 	OPMainnetChainName = "op-mainnet"
-	OPGoerliChainName  = "op-goerli"
 	OPSepoliaChainName = "op-sepolia"
 
 	BobaMainnetChainName = "boba-mainnet"
 	BobaSepoliaChainName = "boba-sepolia"
 
 	LegacyOPMainnetChainName = "optimism-mainnet"
-	LegacyOPGoerliChainName  = "optimism-goerli"
 	LegacyOPSepoliaChainName = "optimism-sepolia"
 )
 
@@ -40,7 +38,6 @@ var All = []string{
 
 	OPMainnetChainName,
 	OPSepoliaChainName,
-	OPGoerliChainName,
 
 	BobaMainnetChainName,
 	BobaSepoliaChainName,
@@ -48,8 +45,6 @@ var All = []string{
 
 func HandleLegacyName(name string) string {
 	switch name {
-	case LegacyOPGoerliChainName:
-		return OPGoerliChainName
 	case LegacyOPSepoliaChainName:
 		return OPSepoliaChainName
 	case LegacyOPMainnetChainName:

--- a/go.mod
+++ b/go.mod
@@ -302,4 +302,4 @@ replace github.com/ledgerwatch/erigon-lib => ./erigon-lib
 
 replace github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.12
 
-replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240621015329-5215351945d3
+replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240709155336-a98d1dc97fa3

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHlV4j7NEo=
 github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240621015329-5215351945d3 h1:5p8H5G4WcaoTRacLqcB1S8mVUoESAmF5zpQhNK3xeo8=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240621015329-5215351945d3/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240709155336-a98d1dc97fa3 h1:rl/ml7j466rE57UfkZvaqbeKwYugdyN2osYQabXlbxo=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240709155336-a98d1dc97fa3/go.mod h1:7xh2awFQqsiZxFrHKTgEd+InVfDRrkKVUIuK8SAFHp0=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/iter v0.0.0-20140124041915-454541ec3da2/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=
 github.com/bradfitz/iter v0.0.0-20190303215204-33e6a9893b0c/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=

--- a/params/config.go
+++ b/params/config.go
@@ -74,7 +74,6 @@ var (
 	ChiadoGenesisHash     = libcommon.HexToHash("0xada44fd8d2ecab8b08f256af07ad3e777f17fb434f8f8e678b312f576212ba9a")
 
 	OPMainnetGenesisHash = libcommon.HexToHash("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b")
-	OPGoerliGenesisHash  = libcommon.HexToHash("0xc1fc15cd51159b1f1e5cbc4b82e85c1447ddfa33c52cf1d98d14fba0d6354be1")
 	OPSepoliaGenesisHash = libcommon.HexToHash("0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d")
 
 	BobaMainnetGenesisHash = libcommon.HexToHash("0xdcd9e6a8f9973eaa62da2874959cb152faeb4fd6929177bd6335a1a16074ef9c")
@@ -299,9 +298,6 @@ func GenesisHashByChainName(chain string) *libcommon.Hash {
 	case networkname.OPMainnetChainName:
 		// cannot use genesis hash from superchain registry because of pre-bedrock blocks
 		return &OPMainnetGenesisHash
-	case networkname.OPGoerliChainName:
-		// cannot use genesis has from superchain registry because of pre-bedrock blocks
-		return &OPGoerliGenesisHash
 	case networkname.OPSepoliaChainName:
 		return &OPSepoliaGenesisHash
 	case networkname.BobaMainnetChainName:

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -12,29 +12,22 @@ import (
 )
 
 const (
-	OPMainnetChainID        = 10
-	OPGoerliChainID         = 420
-	OPSepoliaChainID        = 11155420
-	BaseMainnetChainID      = 8453
-	BaseGoerliChainID       = 84531
-	baseSepoliaChainID      = 84532
-	baseGoerliDevnetChainID = 11763071
-	pgnSepoliaChainID       = 58008
-	devnetChainID           = 997
-	chaosnetChainID         = 888
-	BobaMainnetChainID      = 288
-	BobaSepoliaChainID      = 28882
-	BobaBnbTestnetChainID   = 9728
+	OPMainnetChainID      = 10
+	OPSepoliaChainID      = 11155420
+	BaseMainnetChainID    = 8453
+	baseSepoliaChainID    = 84532
+	pgnSepoliaChainID     = 58008
+	devnetChainID         = 997
+	chaosnetChainID       = 888
+	BobaMainnetChainID    = 288
+	BobaSepoliaChainID    = 28882
+	BobaBnbTestnetChainID = 9728
 )
 
 // OP Stack chain config
 var (
 	// March 17, 2023 @ 7:00:00 pm UTC
 	OptimismGoerliRegolithTime = big.NewInt(1679079600)
-	// May 4, 2023 @ 5:00:00 pm UTC
-	BaseGoerliRegolithTime = big.NewInt(1683219600)
-	// Apr 21, 2023 @ 6:30:00 pm UTC
-	baseGoerliDevnetRegolithTime = big.NewInt(1682101800)
 	// March 5, 2023 @ 2:48:00 am UTC
 	devnetRegolithTime = big.NewInt(1677984480)
 	// August 16, 2023 @ 3:34:22 am UTC
@@ -68,6 +61,10 @@ func OPStackChainConfigByGenesisHash(genesisHash common.Hash) *superchain.ChainC
 		return superchain.OPChains[OPSepoliaChainID]
 	} else if bytes.Equal(genesisHash.Bytes(), BobaSepoliaGenesisHash.Bytes()) {
 		return superchain.OPChains[BobaSepoliaChainID]
+	} else if bytes.Equal(genesisHash.Bytes(), BobaMainnetGenesisHash.Bytes()) {
+		return superchain.OPChains[BobaMainnetChainID]
+	} else if bytes.Equal(genesisHash.Bytes(), BobaBnbTestnetGenesisHash.Bytes()) {
+		return superchain.OPChains[BobaBnbTestnetChainID]
 	}
 	for _, chainCfg := range superchain.OPChains {
 		if bytes.Equal(chainCfg.Genesis.L2.Hash[:], genesisHash.Bytes()) {
@@ -156,14 +153,6 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 
 	// special overrides for OP-Stack chains with pre-Regolith upgrade history
 	switch opStackChainCfg.ChainID {
-	case OPGoerliChainID:
-		out.LondonBlock = big.NewInt(4061224)
-		out.ArrowGlacierBlock = big.NewInt(4061224)
-		out.GrayGlacierBlock = big.NewInt(4061224)
-		out.MergeNetsplitBlock = big.NewInt(4061224)
-		out.BedrockBlock = big.NewInt(4061224)
-		out.RegolithTime = OptimismGoerliRegolithTime
-		out.Optimism.EIP1559Elasticity = 10
 	case OPMainnetChainID:
 		out.BerlinBlock = big.NewInt(3950000)
 		out.LondonBlock = big.NewInt(105235063)
@@ -171,13 +160,8 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		out.GrayGlacierBlock = big.NewInt(105235063)
 		out.MergeNetsplitBlock = big.NewInt(105235063)
 		out.BedrockBlock = big.NewInt(105235063)
-	case BaseGoerliChainID:
-		out.RegolithTime = BaseGoerliRegolithTime
-		out.Optimism.EIP1559Elasticity = 10
 	case baseSepoliaChainID:
 		out.Optimism.EIP1559Elasticity = 10
-	case baseGoerliDevnetChainID:
-		out.RegolithTime = baseGoerliDevnetRegolithTime
 	case pgnSepoliaChainID:
 		out.Optimism.EIP1559Elasticity = 2
 		out.Optimism.EIP1559Denominator = 8
@@ -195,12 +179,6 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		out.MergeNetsplitBlock = big.NewInt(511)
 		out.BedrockBlock = big.NewInt(511)
 		out.RegolithTime = BobaSepoliaRegolithTime
-		out.ShanghaiTime = BobaSepoliaRegolithTime
-		out.CanyonTime = BobaSepoliaRegolithTime
-		out.Optimism.EIP1559Elasticity = 6
-		out.Optimism.EIP1559Denominator = 50
-		out.Optimism.EIP1559DenominatorCanyon = 250
-		out.FjordTime = nil
 	case BobaMainnetChainID:
 		out.BerlinBlock = big.NewInt(1149019)
 		out.LondonBlock = big.NewInt(1149019)
@@ -209,12 +187,6 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		out.MergeNetsplitBlock = big.NewInt(1149019)
 		out.BedrockBlock = big.NewInt(1149019)
 		out.RegolithTime = BobaMainnetRegolithTime
-		out.ShanghaiTime = BobaMainnetRegolithTime
-		out.CanyonTime = BobaMainnetRegolithTime
-		out.Optimism.EIP1559Elasticity = 6
-		out.Optimism.EIP1559Denominator = 50
-		out.Optimism.EIP1559DenominatorCanyon = 250
-		out.FjordTime = nil
 	case BobaBnbTestnetChainID:
 		out.BerlinBlock = big.NewInt(675077)
 		out.LondonBlock = big.NewInt(675077)
@@ -223,12 +195,6 @@ func LoadSuperChainConfig(opStackChainCfg *superchain.ChainConfig) *chain.Config
 		out.MergeNetsplitBlock = big.NewInt(675077)
 		out.BedrockBlock = big.NewInt(675077)
 		out.RegolithTime = BobaBnbTestnetRegoTime
-		out.ShanghaiTime = BobaBnbTestnetRegoTime
-		out.CanyonTime = BobaBnbTestnetRegoTime
-		out.Optimism.EIP1559Elasticity = 6
-		out.Optimism.EIP1559Denominator = 50
-		out.Optimism.EIP1559DenominatorCanyon = 250
-		out.FjordTime = nil
 	}
 
 	return out

--- a/params/superchain_test.go
+++ b/params/superchain_test.go
@@ -1,0 +1,157 @@
+package params
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ledgerwatch/erigon-lib/common"
+	"github.com/stretchr/testify/require"
+)
+
+type hardforkConfig struct {
+	chainID                  uint64
+	ShanghaiTime             *big.Int
+	CancunTime               *big.Int
+	BedrockBlock             *big.Int
+	RegolithTime             *big.Int
+	CanyonTime               *big.Int
+	EcotoneTime              *big.Int
+	FjordTime                *big.Int
+	EIP1559Elasticity        uint64
+	EIP1559Denominator       uint64
+	EIP1559DenominatorCanyon uint64
+}
+
+var bobaSepoliaCfg = hardforkConfig{
+	chainID:                  28882,
+	ShanghaiTime:             big.NewInt(1705600788),
+	CancunTime:               big.NewInt(1709078400),
+	BedrockBlock:             big.NewInt(511),
+	RegolithTime:             big.NewInt(1705600788),
+	CanyonTime:               big.NewInt(1705600788),
+	EcotoneTime:              big.NewInt(1709078400),
+	FjordTime:                big.NewInt(1722297600),
+	EIP1559Elasticity:        6,
+	EIP1559Denominator:       50,
+	EIP1559DenominatorCanyon: 250,
+}
+
+var bobaMainnetCfg = hardforkConfig{
+	chainID:                  288,
+	ShanghaiTime:             big.NewInt(1713302879),
+	CancunTime:               big.NewInt(1713302880),
+	BedrockBlock:             big.NewInt(1149019),
+	RegolithTime:             big.NewInt(1713302879),
+	CanyonTime:               big.NewInt(1713302879),
+	EcotoneTime:              big.NewInt(1713302880),
+	FjordTime:                nil,
+	EIP1559Elasticity:        6,
+	EIP1559Denominator:       50,
+	EIP1559DenominatorCanyon: 250,
+}
+
+var bobaBnbTestnetCfg = hardforkConfig{
+	chainID:                  9728,
+	ShanghaiTime:             big.NewInt(1718920167),
+	CancunTime:               big.NewInt(1718920168),
+	BedrockBlock:             big.NewInt(675077),
+	RegolithTime:             big.NewInt(1718920167),
+	CanyonTime:               big.NewInt(1718920167),
+	EcotoneTime:              big.NewInt(1718920168),
+	FjordTime:                big.NewInt(1722297600),
+	EIP1559Elasticity:        6,
+	EIP1559Denominator:       50,
+	EIP1559DenominatorCanyon: 250,
+}
+
+var opSepoliaCfg = hardforkConfig{
+	chainID:                  11155420,
+	ShanghaiTime:             big.NewInt(1699981200),
+	CancunTime:               big.NewInt(1708534800),
+	BedrockBlock:             big.NewInt(0),
+	RegolithTime:             big.NewInt(0),
+	CanyonTime:               big.NewInt(1699981200),
+	EcotoneTime:              big.NewInt(1708534800),
+	FjordTime:                big.NewInt(1716998400),
+	EIP1559Elasticity:        6,
+	EIP1559Denominator:       50,
+	EIP1559DenominatorCanyon: 250,
+}
+
+var opMainnetCfg = hardforkConfig{
+	chainID:                  10,
+	ShanghaiTime:             big.NewInt(1704992401),
+	CancunTime:               big.NewInt(1710374401),
+	BedrockBlock:             big.NewInt(105235063),
+	RegolithTime:             big.NewInt(0),
+	CanyonTime:               big.NewInt(1704992401),
+	EcotoneTime:              big.NewInt(1710374401),
+	FjordTime:                big.NewInt(1720627201),
+	EIP1559Elasticity:        6,
+	EIP1559Denominator:       50,
+	EIP1559DenominatorCanyon: 250,
+}
+
+func TestChainConfigByOpStackChainName(t *testing.T) {
+	hardforkConfigsByName := map[string]hardforkConfig{
+		"boba-sepolia":     bobaSepoliaCfg,
+		"boba-mainnet":     bobaMainnetCfg,
+		"boba-bnb-testnet": bobaBnbTestnetCfg,
+		"op-sepolia":       opSepoliaCfg,
+		"op-mainnet":       opMainnetCfg,
+	}
+
+	for name, expectedHarhardforkCfg := range hardforkConfigsByName {
+		gotCfg := ChainConfigByOpStackChainName(name)
+		require.NotNil(t, gotCfg)
+
+		// ChainID
+		require.Equal(t, expectedHarhardforkCfg.chainID, gotCfg.ChainID.Uint64())
+
+		// Hardforks
+		require.Equal(t, expectedHarhardforkCfg.ShanghaiTime, gotCfg.ShanghaiTime)
+		require.Equal(t, expectedHarhardforkCfg.CancunTime, gotCfg.CancunTime)
+		require.Equal(t, expectedHarhardforkCfg.BedrockBlock, gotCfg.BedrockBlock)
+		require.Equal(t, expectedHarhardforkCfg.RegolithTime, gotCfg.RegolithTime)
+		require.Equal(t, expectedHarhardforkCfg.CanyonTime, gotCfg.CanyonTime)
+		require.Equal(t, expectedHarhardforkCfg.EcotoneTime, gotCfg.EcotoneTime)
+		require.Equal(t, expectedHarhardforkCfg.FjordTime, gotCfg.FjordTime)
+
+		// EIP-1559
+		require.Equal(t, expectedHarhardforkCfg.EIP1559Elasticity, gotCfg.Optimism.EIP1559Elasticity)
+		require.Equal(t, expectedHarhardforkCfg.EIP1559Denominator, gotCfg.Optimism.EIP1559Denominator)
+		require.Equal(t, expectedHarhardforkCfg.EIP1559DenominatorCanyon, gotCfg.Optimism.EIP1559DenominatorCanyon)
+	}
+}
+
+func TestChainConfigByOpStackGenesisHash(t *testing.T) {
+	hardforkConfigsByName := map[common.Hash]hardforkConfig{
+		BobaSepoliaGenesisHash:    bobaSepoliaCfg,
+		BobaMainnetGenesisHash:    bobaMainnetCfg,
+		BobaBnbTestnetGenesisHash: bobaBnbTestnetCfg,
+		OPSepoliaGenesisHash:      opSepoliaCfg,
+		OPMainnetGenesisHash:      opMainnetCfg,
+	}
+
+	for genesisHash, expectedHarhardforkCfg := range hardforkConfigsByName {
+		gotCfg := ChainConfigByOpStackGenesisHash(genesisHash)
+		require.NotNil(t, gotCfg)
+
+		// ChainID
+		require.Equal(t, expectedHarhardforkCfg.chainID, gotCfg.ChainID.Uint64())
+
+		// Hardforks
+		require.Equal(t, expectedHarhardforkCfg.ShanghaiTime, gotCfg.ShanghaiTime)
+		require.Equal(t, expectedHarhardforkCfg.CancunTime, gotCfg.CancunTime)
+		require.Equal(t, expectedHarhardforkCfg.BedrockBlock, gotCfg.BedrockBlock)
+		require.Equal(t, expectedHarhardforkCfg.RegolithTime, gotCfg.RegolithTime)
+		require.Equal(t, expectedHarhardforkCfg.CanyonTime, gotCfg.CanyonTime)
+		require.Equal(t, expectedHarhardforkCfg.EcotoneTime, gotCfg.EcotoneTime)
+		require.Equal(t, expectedHarhardforkCfg.FjordTime, gotCfg.FjordTime)
+
+		// EIP-1559
+		require.Equal(t, expectedHarhardforkCfg.EIP1559Elasticity, gotCfg.Optimism.EIP1559Elasticity)
+		require.Equal(t, expectedHarhardforkCfg.EIP1559Denominator, gotCfg.Optimism.EIP1559Denominator)
+		require.Equal(t, expectedHarhardforkCfg.EIP1559DenominatorCanyon, gotCfg.Optimism.EIP1559DenominatorCanyon)
+	}
+}


### PR DESCRIPTION
This PR upgrades the superchain-registry repo to enable the fjord hardfork at 1722297600 on Boba Sepolia L2 and Boba BNB Testnet L2.

Unit tests are added to verify that we have the same hardfork block numbers as the superchain-registry repo.

The Goerli networks are removed.