### PR TITLE
Activate Granite hardfork on boba devnet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -298,4 +298,4 @@ replace github.com/anacrolix/torrent => github.com/erigontech/torrent v1.54.2-al
 
 replace github.com/ledgerwatch/erigon-lib => ./erigon-lib
 
-replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240827163850-4bff0d8a9936
+replace github.com/ethereum-optimism/superchain-registry/superchain => github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240828175039-e5ea9ca832a9

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240827163850-4bff0d8a9936 h1:4np1Iuf9RWW/P1SbiB/tx9lYsi61x5BSd95BPLFlKFI=
-github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240827163850-4bff0d8a9936/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240828175039-e5ea9ca832a9 h1:VLFGNG3KH3Heu8DpDt/Hj411ZnSWG05rZzYVmX4KcvY=
+github.com/bobanetwork/superchain-registry/superchain v0.0.0-20240828175039-e5ea9ca832a9/go.mod h1:zy9f3TNPS7pwW4msMitF83fp0Wf452tZ6+Fg6d4JyXM=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bradfitz/iter v0.0.0-20140124041915-454541ec3da2/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=
 github.com/bradfitz/iter v0.0.0-20190303215204-33e6a9893b0c/go.mod h1:PyRFw1Lt2wKX4ZVSQ2mk+PeDa1rxyObEDlApuIsUKuo=

--- a/params/superchain_test.go
+++ b/params/superchain_test.go
@@ -77,7 +77,7 @@ var bobaSepoliaDev0Cfg = hardforkConfig{
 	CanyonTime:               big.NewInt(1724692140),
 	EcotoneTime:              big.NewInt(1724692141),
 	FjordTime:                big.NewInt(1724692150),
-	GraniteTime:              nil,
+	GraniteTime:              big.NewInt(1724914800),
 	EIP1559Elasticity:        6,
 	EIP1559Denominator:       50,
 	EIP1559DenominatorCanyon: 250,


### PR DESCRIPTION
Update superchain-registry repo to activate the Granite hardfork on boba devnet