### PR TITLE
Update default ci machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
         type: boolean
         default: false
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:edge
       resource_class: xlarge
     steps:
       - gcp-cli/install


### PR DESCRIPTION
The old machine image is deprecated by Circle CI.